### PR TITLE
Make sure empty streams get deflated properly

### DIFF
--- a/core/jvm/src/main/scala/fs2/compress.scala
+++ b/core/jvm/src/main/scala/fs2/compress.scala
@@ -22,12 +22,12 @@ object compress {
               bufferSize: Int = 1024 * 32,
               strategy: Int = Deflater.DEFAULT_STRATEGY): Pipe[F,Byte,Byte] = {
     val pure: Pipe[Pure,Byte,Byte] =
-      _ pull { _.await flatMap { step =>
+      _ pull {
         val deflater = new Deflater(level, nowrap)
         deflater.setStrategy(strategy)
         val buffer = new Array[Byte](bufferSize)
-        _deflate_step(deflater, buffer)(step)
-      }}
+        _deflate_handle(deflater, buffer)
+      }
     pipe.covary[F,Byte,Byte](pure)
   }
   private def _deflate_step(deflater: Deflater, buffer: Array[Byte]): ((Chunk[Byte], Handle[Pure, Byte])) => Pull[Pure, Byte, Handle[Pure, Byte]] = {

--- a/core/jvm/src/test/scala/fs2/CompressSpec.scala
+++ b/core/jvm/src/test/scala/fs2/CompressSpec.scala
@@ -4,20 +4,63 @@ import fs2.Stream._
 
 import compress._
 
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
+
+import java.io.ByteArrayOutputStream
+import java.util.zip.{Deflater, DeflaterOutputStream, Inflater, InflaterOutputStream}
+
 class CompressSpec extends Fs2Spec {
 
   def getBytes(s: String): Array[Byte] =
     s.getBytes
 
+  def deflateStream(b: Array[Byte], level: Int, nowrap: Boolean): Array[Byte] = {
+    val byteArrayStream = new ByteArrayOutputStream()
+    val deflaterStream = new DeflaterOutputStream(byteArrayStream, new Deflater(level, nowrap))
+    deflaterStream.write(b)
+    deflaterStream.close()
+    byteArrayStream.toByteArray()
+  }
+
+  def inflateStream(b: Array[Byte], nowrap: Boolean): Array[Byte] = {
+    val byteArrayStream = new ByteArrayOutputStream()
+    val inflaterStream = new InflaterOutputStream(byteArrayStream, new Inflater(nowrap))
+    inflaterStream.write(b)
+    inflaterStream.close()
+    byteArrayStream.toByteArray()
+  }
+
   "Compress" - {
 
-    "deflate.empty input" in {
-      assert(Stream.empty[Pure, Byte].through(deflate()).toVector.isEmpty)
-    }
+    "deflate input" in forAll(arbitrary[String], Gen.choose(0, 9), arbitrary[Boolean])
+      { (s: String, level: Int, nowrap: Boolean) =>
+        val expected = deflateStream(getBytes(s), level, nowrap).toVector
+        val actual = Stream.chunk(Chunk.bytes(getBytes(s))).throughPure(deflate(
+          level = level,
+          nowrap = nowrap
+        )).toVector
 
-    "inflate.empty input" in {
-      assert(Stream.empty[Pure, Byte].through(inflate()).toVector.isEmpty)
-    }
+        actual should equal(expected)
+      }
+
+    "inflate input" in forAll(arbitrary[String], Gen.choose(0, 9), arbitrary[Boolean])
+      { (s: String, level: Int, nowrap: Boolean) =>
+        val expectedDeflated = deflateStream(getBytes(s), level, nowrap)
+        val actualDeflated = Stream.chunk(Chunk.bytes(getBytes(s))).throughPure(deflate(
+          level = level,
+          nowrap = nowrap
+        )).toVector
+
+        def expectEqual(expected: Array[Byte], actual: Array[Byte]) = {
+          val expectedInflated = inflateStream(expected, nowrap).toVector
+          val actualInflated = Stream.chunk(Chunk.bytes(actual)).throughPure(inflate(nowrap = nowrap)).toVector
+          actualInflated should equal(expectedInflated)
+        }
+
+        expectEqual(actualDeflated.toArray, expectedDeflated.toArray)
+        expectEqual(expectedDeflated.toArray, actualDeflated.toArray)
+      }
 
     "deflate |> inflate ~= id" in forAll { (s: PureStream[Byte]) =>
       s.get.toVector shouldBe s.get.through(compress.deflate()).through(compress.inflate()).toVector


### PR DESCRIPTION
The current behavior of `fs2.compress.deflate` is to skip deflation on empty streams. I would argue that this behavior is incorrect given the following example:

```scala
import java.io.ByteArrayOutputStream
import java.util.zip.{Deflater, DeflaterOutputStream}

val byteArrayStream = new ByteArrayOutputStream()
val deflater = new Deflater(Deflater.DEFAULT_COMPRESSION, true)
val deflaterStream = new DeflaterOutputStream(byteArrayStream, deflater)
deflaterStream.write(Array[Byte]())
deflaterStream.close()
byteArrayStream.toByteArray()
// => Array(3, 0)
```

These changes fix the behavior by making sure that `_deflate_finish` is called regardless of whether the stream was empty or not.